### PR TITLE
JWT fix and stale account fix

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -304,7 +304,9 @@ export class SouthernCompanyAPI{
 		const resData = await Promise.all(responses.map((response)=> response.json())) as MonthlyDataResponse[];
 
 		/* Grabbing data from all responses */
-		const monthlyData = resData.map((response, index)=> {
+		const monthlyData = resData.filter(response => {
+			return JSON.parse(response.Data.Data) !== null;
+		}).map((response, index)=> {
 			/* Parsing graph data */
 			const chartData = JSON.parse(response.Data.Data);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 /* Libraries */
-import fetch from 'node-fetch';
+import fetch, { RequestRedirect } from 'node-fetch';
 import parseISO from 'date-fns/parseISO';
 
 /* Interfaces */
@@ -119,13 +119,14 @@ export class SouthernCompanyAPI{
 			headers: {
 				'Content-Type': 'application/x-www-form-urlencoded'
 			},
-			body: `ScWebToken=${ScWebToken}`
+			body: `ScWebToken=${ScWebToken}`,
+			redirect: "manual" as RequestRedirect
 		};
 
-		const swtresponse = await fetch('https://customerservice2.southerncompany.com/Account/LoginComplete?ReturnUrl=null', swtoptions);
+		const swtresponse = await fetch('https://customerservice2.southerncompany.com/Account/LoginComplete?ReturnUrl=/Billing/Home', swtoptions);
 
 		/* Checking for unsuccessful login */
-		if(swtresponse.status !== 200){
+		if(swtresponse.status !== 302){
 			const cook = swtresponse.headers.get('set-cookie');
 			throw new Error(`Failed to get secondary ScWebToken: ${swtresponse.statusText} ${cook} ${JSON.stringify(swtoptions)}`);
 		}


### PR DESCRIPTION
* `LoginComplete` now 500s on a `null` being sent as the `ReturnUrl`. Send a valid value.
* `LoginComplete` now returns a 302 on success.
* Handles stale accounts with no data

Credit to @Lash-L for fix (ref: https://github.com/Lash-L/southern_company_api/commit/cf4e60762a9d0db5dac320f778f2606e97d8507c) and @carlosmtobon for pair programming 🤝🏻

✅ All tests run and pass.