### PR TITLE
feat: add Nicor Gas (LDC=7) support with cookie-based auth and usage …

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,83 @@ console.info('Daily Data', JSON.stringify(data));
 ```
 
 
+## Nicor Gas (LDC 7)
+
+Nicor Gas uses a **cookie-based session** instead of the JWT flow used by the Southern Company electric utilities. Credentials are submitted directly to the Southern Company customer portal (`customerportal.southerncompany.com`), and all subsequent requests are authenticated via browser-style cookies.
+
+### Login (Nicor)
+```typescript
+import { NicorAPI } from 'southern-company-api';
+
+const API = new NicorAPI({
+  username: 'username',
+  password: 'password'
+});
+
+await API.login();
+```
+
+### getNicorUsageHistory()
+**Description**
+Fetches meter reading history and daily usage data from the Nicor Gas portal for the authenticated account.
+
+**Arguments**
+  * None
+
+**Returns**
+  * Promise
+
+**Promise Return**
+  * `accountId` Account number as a string
+  * `projectedBill` Low-end projected bill amount for the current billing period (number)
+  * `usageHistory` Each object is one billing period
+      * `Date` Billing read date (MM/DD/YYYY)
+      * `MeterReading` Cumulative meter reading
+      * `ReadingDetails` `"Actual"` or `"Estimated"`
+      * `CCfs` Usage in CCF for the period
+      * `Therms` Usage in Therms for the period
+      * `DaysUsed` Number of days in the billing period
+  * `dailyUsage` Each object is one day of usage across all available billing periods
+      * `date` JavaScript `Date` object for the day
+      * `dayOfWeek` e.g. `"Monday"`
+      * `therms` Therms consumed
+      * `cost` Dollar cost for the day
+      * `avgTemp` Average temperature (°F)
+      * `meterRead` Cumulative meter read value
+      * `readType` `"ACTUAL"` or `"ESTIMATED"`
+      * `billingPeriod` Billing period range string, e.g. `"3/30/26-4/24/26"`
+
+**Example**
+```typescript
+import { NicorAPI } from 'southern-company-api';
+
+const API = new NicorAPI({ username: 'username', password: 'password' });
+await API.login();
+
+const data = await API.getNicorUsageHistory();
+
+console.info('Account ID:', data.accountId);
+console.info('Projected Bill:', data.projectedBill);
+
+/* Billing period rollups */
+console.info('Usage History', JSON.stringify(data.usageHistory));
+
+/* Result */
+[
+  { "Date": "03/30/2026", "MeterReading": "3454.000000", "ReadingDetails": "Actual", "CCfs": 95, "Therms": 99.75, "DaysUsed": 31 },
+  { "Date": "02/27/2026", "MeterReading": "3359.000000", "ReadingDetails": "Actual", "CCfs": 151, "Therms": 158.55, "DaysUsed": 30 }
+]
+
+/* Per-day records */
+console.info('Daily Usage', JSON.stringify(data.dailyUsage));
+
+/* Result */
+[
+  { "date": "2026-04-23T04:00:00.000Z", "dayOfWeek": "Thursday", "therms": 1.05, "cost": 2.88, "avgTemp": 58, "meterRead": 3493, "readType": "ACTUAL", "billingPeriod": "3/30/26-4/24/26" },
+  { "date": "2026-04-22T04:00:00.000Z", "dayOfWeek": "Wednesday", "therms": 1.05, "cost": 2.88, "avgTemp": 67, "meterRead": 3492, "readType": "ACTUAL", "billingPeriod": "3/30/26-4/24/26" }
+]
+```
+
 ## How Authentication Works
 1. Login Page is loaded
   * `Method` GET

--- a/README.md
+++ b/README.md
@@ -174,6 +174,34 @@ console.info('Daily Data', JSON.stringify(data));
 ```
 
 
+### How Authentication Works
+1. Login Page is loaded
+  * `Method` GET
+  * `URL` https://webauth.southernco.com/account/login
+2. Grab the `RequestVerificationToken` from the login Page
+  * `RequestVerificationToken` can be found at the bottom of the page in a script tag.  Inside the tag the `RequestVerificationToken` is assigned to `webauth.aft`
+3. Login Request is initialized
+  * `Method` POST
+  * `URL` https://webauth.southernco.com/api/login
+  * `Headers`
+    * `RequestVerificationToken`: `RequestVerificationToken`
+    * `Content-Type`: application/json
+  * `Body` (JSON Object):
+    * `username`: `username`
+    * `password`: `password`
+    * `params`
+      * `ReturnUrl` 'null'
+4. Grab the `ScWebToken` from the JSON response. Can be found in the `response.data.html` as a value on a hidden input with the name ScWebToken
+5. Grab the new `ScWebToken` from the set cookies from a secondary LoginComplete request.
+6. This secondary Southern Company Web Token can be traded in for a Southern Company JSON Web Token (`ScJwtToken`) that can be used with the API.
+  * `Method` GET
+  * `URL` https://customerservice2.southerncompany.com/Account/LoginValidated/JwtToken
+  * `Headers`
+    * `Cookie` ScWebToken=`ScWebToken`
+7. Grab the `ScJwtToken` from the response's cookies
+  * Cookie's name is ScJwtToken and contains the ScJwtToken
+  * This `ScJwtToken` can be used to authenticate all other API requests.
+
 ## Nicor Gas (LDC 7)
 
 Nicor Gas uses a **cookie-based session** instead of the JWT flow used by the Southern Company electric utilities. Credentials are submitted directly to the Southern Company customer portal (`customerportal.southerncompany.com`), and all subsequent requests are authenticated via browser-style cookies.
@@ -250,31 +278,3 @@ console.info('Daily Usage', JSON.stringify(data.dailyUsage));
   { "date": "2026-04-22T04:00:00.000Z", "dayOfWeek": "Wednesday", "therms": 1.05, "cost": 2.88, "avgTemp": 67, "meterRead": 3492, "readType": "ACTUAL", "billingPeriod": "3/30/26-4/24/26" }
 ]
 ```
-
-## How Authentication Works
-1. Login Page is loaded
-  * `Method` GET
-  * `URL` https://webauth.southernco.com/account/login
-2. Grab the `RequestVerificationToken` from the login Page
-  * `RequestVerificationToken` can be found at the bottom of the page in a script tag.  Inside the tag the `RequestVerificationToken` is assigned to `webauth.aft`
-3. Login Request is initialized
-  * `Method` POST
-  * `URL` https://webauth.southernco.com/api/login
-  * `Headers`
-    * `RequestVerificationToken`: `RequestVerificationToken`
-    * `Content-Type`: application/json
-  * `Body` (JSON Object):
-    * `username`: `username`
-    * `password`: `password`
-    * `params`
-      * `ReturnUrl` 'null'
-4. Grab the `ScWebToken` from the JSON response. Can be found in the `response.data.html` as a value on a hidden input with the name ScWebToken
-5. Grab the new `ScWebToken` from the set cookies from a secondary LoginComplete request.
-6. This secondary Southern Company Web Token can be traded in for a Southern Company JSON Web Token (`ScJwtToken`) that can be used with the API.
-  * `Method` GET
-  * `URL` https://customerservice2.southerncompany.com/Account/LoginValidated/JwtToken
-  * `Headers`
-    * `Cookie` ScWebToken=`ScWebToken`
-7. Grab the `ScJwtToken` from the response's cookies
-  * Cookie's name is ScJwtToken and contains the ScJwtToken
-  * This `ScJwtToken` can be used to authenticate all other API requests.

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,10 @@
 import fetch, { RequestRedirect } from 'node-fetch';
 import { parseISO } from "date-fns";
 
+/* Nicor Gas (LDC=7) */
+export { NicorAPI, parseAspNetDate } from './nicor';
+export type { NicorConfig, NicorUsageHistoryEntry, NicorDailyUsageEntry, NicorUsageData } from './nicor';
+
 /* Interfaces */
 import { Company, Account } from './interfaces/general';
 import {GetAllAccountsResponse, LoginResponse, MonthlyDataResponse} from './interfaces/responses';

--- a/src/nicor.ts
+++ b/src/nicor.ts
@@ -1,0 +1,170 @@
+/* Libraries */
+import fetch, { RequestRedirect } from 'node-fetch';
+
+/* Interfaces */
+export interface NicorConfig {
+	username: string;
+	password: string;
+}
+
+export interface NicorUsageHistoryEntry {
+	Date: string;
+	MeterReading: string;
+	ReadingDetails: string;
+	CCfs: number;
+	Therms: number;
+	DaysUsed: number;
+}
+
+export interface NicorDailyUsageEntry {
+	date: Date;
+	dayOfWeek: string;
+	therms: number;
+	cost: number;
+	avgTemp: number;
+	meterRead: number;
+	readType: string;
+	billingPeriod: string;
+}
+
+export interface NicorUsageData {
+	usageHistory: NicorUsageHistoryEntry[];
+	dailyUsage: NicorDailyUsageEntry[];
+	projectedBill: number;
+	accountId: string;
+}
+
+/* Parses ASP.NET's /Date(1234567890000)/ serialization to a JavaScript Date */
+export function parseAspNetDate(dateStr: string): Date {
+	const match = /\/Date\((-?\d+)\)\//.exec(dateStr);
+	if (!match) throw new Error(`Invalid ASP.NET date string: ${dateStr}`);
+	return new Date(parseInt(match[1], 10));
+}
+
+export class NicorAPI {
+	private config?: NicorConfig;
+	private cookies: string = '';
+
+	constructor(config?: NicorConfig) {
+		if (config) {
+			this.config = config;
+		}
+	}
+
+	/* node-fetch v2 exposes multiple Set-Cookie headers via headers.raw() */
+	private parseSetCookieHeaders(headers: any): string {
+		const setCookies: string[] = headers.raw()['set-cookie'] || [];
+		return setCookies
+			.map((cookie: string) => {
+				const match = cookie.match(/^([^=]+=[^;]+)/);
+				return match ? match[1] : '';
+			})
+			.filter((c: string) => c)
+			.join('; ');
+	}
+
+	private async getRequestVerificationToken(): Promise<string> {
+		const response = await fetch('https://customerportal.southerncompany.com/User/Login?LDC=7', {
+			headers: { 'User-Agent': 'Mozilla/5.0' }
+		});
+
+		if (response.status !== 200) {
+			throw new Error(`Failed to load login page: ${response.statusText}`);
+		}
+
+		const html = await response.text();
+		const match = /name="__RequestVerificationToken"[^>]+value="([^"]+)"/i.exec(html);
+		if (!match) throw new Error('Could not find __RequestVerificationToken in login page');
+
+		this.cookies = this.parseSetCookieHeaders(response.headers);
+		return match[1];
+	}
+
+	public async login(config?: NicorConfig): Promise<void> {
+		if (config) this.config = config;
+		if (!this.config) throw new Error('Could not login: No config available');
+
+		const token = await this.getRequestVerificationToken();
+
+		const loginResponse = await fetch('https://customerportal.southerncompany.com/User/Login', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/x-www-form-urlencoded',
+				'User-Agent': 'Mozilla/5.0',
+				'Cookie': this.cookies,
+				'Referer': 'https://customerportal.southerncompany.com/User/Login?LDC=7'
+			},
+			body: new URLSearchParams({
+				__RequestVerificationToken: token,
+				UserName: this.config.username,
+				Password: this.config.password,
+				RememberMe: 'false',
+				loginbtn: 'Login'
+			}).toString(),
+			redirect: 'manual' as RequestRedirect
+		});
+
+		if (loginResponse.status !== 302 && loginResponse.status !== 200) {
+			throw new Error(`Login failed: ${loginResponse.statusText}`);
+		}
+
+		const newCookies = this.parseSetCookieHeaders(loginResponse.headers);
+		if (newCookies) {
+			this.cookies = this.cookies ? `${this.cookies}; ${newCookies}` : newCookies;
+		}
+	}
+
+	public async getNicorUsageHistory(): Promise<NicorUsageData> {
+		if (!this.cookies) throw new Error('Not logged in. Call login() first.');
+
+		// The login POST redirects to /Account/AccountSummary where the server
+		// sets the auth session cookie — follow it once to pick that cookie up.
+		const summaryResp = await fetch('https://customerportal.southerncompany.com/Account/AccountSummary', {
+			headers: { 'User-Agent': 'Mozilla/5.0', 'Cookie': this.cookies },
+			redirect: 'manual' as RequestRedirect
+		});
+		const summaryCookies = this.parseSetCookieHeaders(summaryResp.headers);
+		if (summaryCookies) this.cookies = `${this.cookies}; ${summaryCookies}`;
+
+		const response = await fetch('https://customerportal.southerncompany.com/MeterDataManagement/UsageHistory', {
+			headers: {
+				'User-Agent': 'Mozilla/5.0',
+				'Cookie': this.cookies,
+				'Referer': 'https://customerportal.southerncompany.com/'
+			}
+		});
+
+		if (response.status !== 200) {
+			throw new Error(`Failed to get usage history: ${response.statusText}`);
+		}
+
+		const html = await response.text();
+		const vmodelMatch = /var vmodel = '([^']+)'/.exec(html);
+		if (!vmodelMatch) throw new Error('Could not find vmodel data in UsageHistory page');
+		const vmodel = JSON.parse(vmodelMatch[1]);
+
+		const accountIdMatch = /id="AccountID"[^>]+value="([^"]+)"/.exec(html);
+		const accountId = accountIdMatch ? accountIdMatch[1] : '';
+
+		const rawPeriods: any[] = vmodel.AMIUsageMData?.DailyUsage ?? [];
+		const dailyUsage: NicorDailyUsageEntry[] = rawPeriods.flatMap(period =>
+			(period.LabelsHDate as string[]).map((dateStr, i) => ({
+				date: parseAspNetDate(dateStr),
+				dayOfWeek: period.WeekDayorWeekEnd[i],
+				therms: period.DailyThermsList[i],
+				cost: period.DailyCostsList[i],
+				avgTemp: period.DailyAvgTempData[i],
+				meterRead: period.MeterReads[i],
+				readType: period.ReadType[i],
+				billingPeriod: period.BillingPeriodDatesListKey,
+			}))
+		);
+
+		return {
+			usageHistory: vmodel.UsageHistoryCollection,
+			dailyUsage,
+			projectedBill: vmodel.AMIUsageMData?.lowRangeBillAmt ?? 0,
+			accountId,
+		};
+	}
+}


### PR DESCRIPTION
## Summary                      
                                                                                                                                                              
  - Adds `NicorAPI` class for Nicor Gas (LDC 7) accounts, which use cookie-based session auth instead of the JWT flow used by the electric utilities
  - Adds `getNicorUsageHistory()` returning billing-period rollups and flattened per-day records parsed from the server-rendered `vmodel` payload on the    
  UsageHistory page                                                                                                                                           
  - Exports all new types from the package entry point alongside the existing `SouthernCompanyAPI`
  - Updates README with a Nicor Gas section covering auth differences, method docs, and a usage example                                                       
                                                                                                                                                            
  ## Auth flow (Nicor)                                                                                                                                        
                                                                                                                                                            
  1. GET `/User/Login?LDC=7` — extract `__RequestVerificationToken` and session cookie                                                                        
  2. POST credentials to `/User/Login` with `redirect: manual` — collect auth cookies from the 302
  3. GET `/Account/AccountSummary` — follow post-login redirect to complete the session                                                                       
  4. GET `/MeterDataManagement/UsageHistory` — extract `var vmodel = '...'` from HTML, parse JSON                                                             
                                                                                                 
  ## Return shape                                                                                                                                             
                                                                                                                                                              
  ```typescript                                                                                                                                               
  {                                                                                                                                                           
    accountId: string;                                                                                                                                        
    projectedBill: number;                                        
    usageHistory: NicorUsageHistoryEntry[];   // one entry per billing period
    dailyUsage: NicorDailyUsageEntry[];       // one entry per day, ~13 months back
  }

  Test plan                                                                                                                                                 
                                                                                                                                                              
  - Login succeeds with a valid Nicor Gas account
  - usageHistory returns at least one billing period entry                                                                                                    
  - dailyUsage entries have valid Date objects and numeric fields 
  - NicorAPI and all types are importable from 'southern-company-api'                                                                                       
  - Existing SouthernCompanyAPI tests still pass (npm test)   