### PR TITLE
Fix inclusive EndDate, add getHourlyData(), surface hasData

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,12 @@ console.info('Monthly Data', JSON.stringify(monthlyData));
 
 #### getDailyData()
 **Description**
-This method collects daily data from the `startDate` provided to the `endDate` provided.
+This method collects daily data from the `startDate` provided to the `endDate` provided, inclusive of both dates.
 
 **Arguments**
   * `startDate` First date (Date) to include in collection
   * `endDate` Last date (Date) to include in collection
+  * `servicePointNumber` Service point number of the meter to collect data for
 
 **Returns**
   * Promise
@@ -102,7 +103,8 @@ This method collects daily data from the `startDate` provided to the `endDate` p
   * `data` Each index of array is an account retrieved
       * `name` Name of the account
       * `accountNumber` Account number
-      * `data` Each object of array is a month of data
+      * `hasData` `false` if the utility has no data for the requested range (e.g. it falls outside the retention window); `data` will be empty in that case. `true` otherwise.
+      * `data` Each object of array is a day of data
         * `date` M/D/YYYY of data
         * `kWh` Total amount of kWh used during the date
         * `cost` Total energy cost for the date
@@ -112,7 +114,7 @@ This method collects daily data from the `startDate` provided to the `endDate` p
 /* Getting Daily Data */
 const startDate = new Date(2017, 05, 01);
 const endDate = new Date(2017, 05, 02);
-const dailyData = await SouthernCompany.getDailyData(startDate, endDate);
+const dailyData = await SouthernCompany.getDailyData(startDate, endDate, servicePointNumber);
 
 /* Printing daily data */
 console.info('Daily Data', JSON.stringify(data));
@@ -120,11 +122,57 @@ console.info('Daily Data', JSON.stringify(data));
 /* Result */
 [{
   "accountNumber": 0000000000,
+  "hasData": true,
   "data":[
     {"date":"2017-05-01T06:00:00.000Z", "cost":2.17, "kWh":12.76},
     {"date":"2017-05-02T06:00:00.000Z", "cost":77, "kWh":77}
   ]
 }]
+```
+
+
+#### getHourlyData()
+**Description**
+This method collects hourly data from the `startDate` provided to the `endDate` provided, inclusive of both dates. A single call covers the whole range — there's no need to loop per day.
+
+Hourly data is retained by the utility for roughly 3.6 years, considerably deeper than the ~33-day window offered by the portal's own CSV export.
+
+**Arguments**
+  * `startDate` First date (Date) to include in collection
+  * `endDate` Last date (Date) to include in collection
+  * `servicePointNumber` Service point number of the meter to collect data for
+
+**Returns**
+  * Promise
+
+**Promise Return**
+  * `data` Each index of array is an account retrieved
+      * `accountNumber` Account number
+      * `hasData` `false` if the utility has no data for the requested range (e.g. it falls outside the retention window); `data` will be empty in that case. `true` otherwise.
+      * `data` Each object of array is an hour of data
+        * `date` Local timestamp of the hour, transmitted with no UTC offset
+        * `kWh` Total amount of kWh used during the hour
+        * `cost` Total energy cost for the hour
+        * `temp` Temperature during the hour, if reported
+
+**Example**
+```typescript
+/* Getting Hourly Data */
+const startDate = new Date(2026, 06, 24);
+const endDate = new Date(2026, 06, 24);
+const hourlyData = await SouthernCompany.getHourlyData(startDate, endDate, servicePointNumber);
+
+/* Printing hourly data */
+console.info('Hourly Data', JSON.stringify(hourlyData));
+
+/* Result */
+{
+  "accountNumber": 0000000000,
+  "hasData": true,
+  "data":[
+    {"date":"2026-07-24T16:00:00.000Z", "cost":0.31, "kWh":1.2, "temp":91}
+  ]
+}
 ```
 
 

--- a/src/interfaces/API.d.ts
+++ b/src/interfaces/API.d.ts
@@ -470,6 +470,10 @@ declare namespace API {
 		Data: API.MyPowerUsageResponse
 	}
 
+	export interface HourlyDataResponse extends Response{
+		Data: API.MyPowerUsageResponse
+	}
+
 	export interface GetServicePointNumbersResponse extends Response{
 		Data: {
 			estimatedBillIndicator: boolean;
@@ -556,6 +560,52 @@ declare namespace API {
 			}[];
 		};
 		alertCost: {
+			data: any[];
+		};
+		solarGeneration: {
+			data: any[];
+		};
+		solarGenerationDelayed: {
+			data: any[];
+		};
+		};
+		dailyDataSource: string;
+	}
+
+	export interface GetHourlyGraphData {
+		xAxis: {
+		labels: string[];
+		};
+		series: {
+		usage: {
+			data: {
+			x: number;
+			y: number;
+			name: string;
+			resolution: string;
+			}[];
+		};
+		cost: {
+			data: {
+			x: number;
+			y: number;
+			name: string;
+			resolution: string;
+			}[];
+		};
+		temp: {
+			data: {
+			x: number;
+			y: number;
+			name: string;
+			resolution: string;
+			}[];
+		};
+		/* Populated for solar-export accounts only; consistently empty otherwise. Semantics unconfirmed. */
+		costDelayed: {
+			data: any[];
+		};
+		usageDelayed: {
 			data: any[];
 		};
 		solarGeneration: {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 /* Libraries */
 import fetch, { RequestRedirect } from 'node-fetch';
-import { parseISO, format } from "date-fns";
+import { parseISO, format, addDays } from "date-fns";
 
 /* Interfaces */
 import { Company, Account } from './interfaces/general';
@@ -381,8 +381,11 @@ export class SouthernCompanyAPI{
 		}
 
 		/* Formatting dates to MM/DD/YYYY */
+		// The MPUData endpoint treats EndDate as exclusive (half-open range),
+		// so we add a day to make this method's endDate argument inclusive,
+		// matching what the parameter name implies and what the README documents.
 		const startDateString = format(startDate, 'MM/dd/yyyy');
-		const endDateString = format(endDate, 'MM/dd/yyyy');
+		const endDateString = format(addDays(endDate, 1), 'MM/dd/yyyy');
 
 		/* Calulating which accounts to fetch data from */
 		const accounts = this.getConfigAccounts();
@@ -405,6 +408,15 @@ export class SouthernCompanyAPI{
 		});
 
 		const data = await res.json() as API.DailyDataResponse;
+
+		/* Aged-out or malformed ranges come back as HTTP 200 with HasData: false and Data.Data: null. */
+		if(!data.Data.HasData || !data.Data.Data){
+			return {
+				accountNumber: account.number,
+				hasData: false,
+				data: []
+			};
+		}
 
 		const graphData = JSON.parse(data.Data.Data) as API.GetDailyGraphData;
 
@@ -433,10 +445,85 @@ export class SouthernCompanyAPI{
 
 		return {
 			accountNumber: account.number,
+			hasData: true,
 			data: combinedUsageCost.map((d)=>({
 				date: parseISO(d.date),
 				kWh: d.kWh,
 				cost: d.cost
+			}))
+		};
+	}
+
+	public async getHourlyData(startDate: Date, endDate: Date, servicePointNumber: string, jwt?: string){
+		// If no jwt is passed in, login
+		if(!jwt){
+			await this.login(this.config)
+		}
+
+		/* Checking to make sure we have a JWT to use */
+		if(!this.jwt){
+			throw new Error('Could not get hourly data: Not Logged In');
+		}
+
+		/* Formatting dates to MM/DD/YYYY. EndDate is exclusive on the API, so add a day to make this method's endDate argument inclusive. */
+		const startDateString = format(startDate, 'MM/dd/yyyy');
+		const endDateString = format(addDays(endDate, 1), 'MM/dd/yyyy');
+
+		/* Calulating which accounts to fetch data from */
+		const accounts = this.getConfigAccounts();
+
+		/* Figure out which account has the service point number */
+		const account = accounts.find((account)=>{
+			return account.servicePoints.some((servicePoint)=> servicePoint.servicePointNumber === servicePointNumber);
+		});
+
+		if(!account){
+			throw new Error(`Could not find account with service point number ${servicePointNumber}`);
+		}
+
+		/* Creating a request for each account */
+		const res = await fetch(`https://customerservice2api.southerncompany.com/api/MyPowerUsage/MPUData/${account.number}/Hourly?OPCO=${account.company}&StartDate=${startDateString}&EndDate=${endDateString}&intervalBehavior=Automatic&ServicePointNumber=${servicePointNumber}`, {
+			method: 'GET',
+			headers: {
+				Authorization: `Bearer ${this.jwt}`
+			}
+		});
+
+		const data = await res.json() as API.HourlyDataResponse;
+
+		/* Aged-out or malformed ranges come back as HTTP 200 with HasData: false and Data.Data: null. */
+		if(!data.Data.HasData || !data.Data.Data){
+			return {
+				accountNumber: account.number,
+				hasData: false,
+				data: []
+			};
+		}
+
+		const graphData = JSON.parse(data.Data.Data) as API.GetHourlyGraphData;
+
+		const usageCost = graphData.series.usage.data
+		.sort((a, b) => a.x - b.x)
+		.map(({name, y, x})=>{
+			const costEntry = graphData.series.cost.data.find(cost => cost.x === x);
+			const tempEntry = graphData.series.temp.data.find(temp => temp.x === x);
+
+			return {
+				date: name,
+				kWh: y,
+				cost: costEntry?.y || 0,
+				temp: tempEntry?.y
+			};
+		});
+
+		return {
+			accountNumber: account.number,
+			hasData: true,
+			data: usageCost.map((d)=>({
+				date: parseISO(d.date),
+				kWh: d.kWh,
+				cost: d.cost,
+				temp: d.temp
 			}))
 		};
 	}

--- a/tests/data.test.ts
+++ b/tests/data.test.ts
@@ -40,3 +40,39 @@ test('grabs list of daily data', async ()=>{
 	expect(returnedData).toHaveProperty('data');
 	expect(returnedData.data.length).toBe(7);
 });
+
+test('grabs list of hourly data', async ()=>{
+	const accounts = await API.getAccounts();
+	const servicePointNumber = accounts[0].servicePoints[0].servicePointNumber;
+
+	const endDate = new Date();
+	endDate.setDate(endDate.getDate() - 1);
+	const startDate = new Date();
+	startDate.setDate(startDate.getDate() - 2);
+
+	const returnedData = await API.getHourlyData(startDate, endDate, servicePointNumber);
+
+	expect(returnedData).toHaveProperty('accountNumber');
+	expect(returnedData).toHaveProperty('hasData');
+	expect(returnedData).toHaveProperty('data');
+	expect(returnedData.data.length).toBe(48);
+	expect(returnedData.data[0]).toHaveProperty('date');
+	expect(returnedData.data[0]).toHaveProperty('kWh');
+	expect(returnedData.data[0]).toHaveProperty('cost');
+	expect(returnedData.data[0]).toHaveProperty('temp');
+});
+
+test('hourly data with startDate == endDate returns a single day', async ()=>{
+	const accounts = await API.getAccounts();
+	const servicePointNumber = accounts[0].servicePoints[0].servicePointNumber;
+
+	const date = new Date();
+	date.setDate(date.getDate() - 1);
+
+	const returnedData = await API.getHourlyData(date, date, servicePointNumber);
+
+	expect(returnedData).toHaveProperty('hasData');
+	if(returnedData.hasData){
+		expect(returnedData.data.length).toBe(24);
+	}
+});


### PR DESCRIPTION
Addresses items 1, 3, 4, and 5 from #170 (item 2 mentioned in that issue is being handled separately by the maintainer).

## 1. Inclusive `EndDate`
`MPUData`'s date range is half-open (`[StartDate, EndDate)`), so `getDailyData()` was returning one fewer day than requested — and the `startDate == endDate` case came back looking like a utility-side data gap (`HasData: false`) instead of returning the single requested day. Fixed by adding a day to `endDate` internally before formatting, so the public argument is inclusive — matching what the parameter name implies and what the README already documented. Applied the same fix to the new `getHourlyData()` below.

Worth noting this is a behavior change for any caller who was already compensating by passing `end + 1` themselves, so a minor version bump on release seems right, per the discussion on #170.

## 3. `getHourlyData()`
Adds support for the `/Hourly` interval alongside the existing `/Monthly` and `/Daily`. A few things that don't carry over from `getDailyData()`:
- Hourly's series are `usage`/`cost`/`temp` (no weekday/weekend split), so it uses its own `GetHourlyGraphData` response shape rather than reusing `GetDailyGraphData`.
- One call returns usage, cost, and temperature together — there's no separate unit request.
- A multi-day range comes back in a single call, no per-day looping needed.
- `date` values are naive local time with no UTC offset, same caveat around DST as the underlying API — flagged in the README.
- The `*Delayed` and `solarGeneration*` series are included in the type but were consistently empty against a non-exporting account, so their semantics are unconfirmed (possibly solar-export accounts only).

## 4. Hourly retention documented
Bisecting `StartDate`, hourly data is retained for roughly 3.6 years — much deeper than the ~33-day window in the portal's own CSV export. Noted in the README since it changes what's practical for backfilling.

## 5. `HasData` surfaced
Both `getDailyData()` and `getHourlyData()` now return `hasData: boolean` alongside `data`, instead of silently collapsing "no data for this range" (HTTP 200, `HasData: false`, `Data.Data: null`) into an indistinguishable empty array. This matters for anything writing results into a database, where "no data" and "zero usage" need to stay distinguishable.

## Testing
`npx tsc --noEmit` passes. The existing test suite (`tests/*.test.ts`) requires live account credentials via env vars, so I wasn't able to run it against a real account from here — happy to have you verify against yours, or I can if you want to share test credentials for a throwaway/sandbox scenario.